### PR TITLE
Split portfolio into multi-page site

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hazem Sabu — CRM Manager · Real Estate</title>
+  <title>Hazem Sabu — Admin & Governance</title>
   <meta name="description" content="Commercial & Residential CRM: pipelines, automations, data, reporting, and adoption." />
   <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23000000'/><text x='50' y='58' font-size='54' text-anchor='middle' fill='white' font-family='Arial'>CRM</text></svg>">
@@ -48,40 +48,41 @@
     </div>
   </header>
 
-  <!-- Overview / Hero -->
-  <section id="overview" class="relative overflow-hidden">
-    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
-      <div class="absolute -top-40 -left-40 w-96 h-96 rounded-full blur-3xl opacity-20 bg-indigo-400"></div>
-      <div class="absolute -bottom-48 -right-40 w-[34rem] h-[34rem] rounded-full blur-3xl opacity-20 bg-fuchsia-500"></div>
-    </div>
+    <!-- Governance -->
+  <section id="governance" class="container-narrow px-4 py-14">
+    <h2 class="text-2xl md:text-3xl font-bold">System Administration & Governance</h2>
+    <p class="mt-3 text-zinc-600 dark:text-zinc-300">Security, roles, rollout discipline, and continuous improvement.</p>
 
-    <div class="container-narrow px-4 py-16">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
-        <div>
-          <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">Real Estate CRM Portfolio</h1>
-          <p class="mt-4 text-zinc-600 dark:text-zinc-300 text-lg">Commercial & Residential pipelines, lead scoring, automations, reporting, and governance—designed to cut response time, improve conversion, and keep data clean.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <a href="pipelines.html" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">View Work</a>
-            <a href="contact.html" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Get in touch</a>
-          </div>
-          <div class="mt-6 text-xs text-zinc-500 dark:text-zinc-400">Bitrix24 • HubSpot • Salesforce • Make/Zapier • Telephony • Property portals</div>
-        </div>
-        <div class="bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
-          <h3 class="font-semibold">What I cover</h3>
-          <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-            <li class="flex items-start gap-2"><span>✅</span>Lead capture & routing</li>
-            <li class="flex items-start gap-2"><span>✅</span>Lead scoring & qualification</li>
-            <li class="flex items-start gap-2"><span>✅</span>Sales funnels by lead type</li>
-            <li class="flex items-start gap-2"><span>✅</span>Automations & SLAs</li>
-            <li class="flex items-start gap-2"><span>✅</span>Dashboards & insights</li>
-            <li class="flex items-start gap-2"><span>✅</span>Data integrity & governance</li>
-            <li class="flex items-start gap-2"><span>✅</span>Training & enablement</li>
-            <li class="flex items-start gap-2"><span>✅</span>System administration</li>
-          </ul>
-        </div>
+    <div class="mt-6 grid lg:grid-cols-3 gap-6 text-sm">
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Access & Roles</h3>
+        <ul class="mt-2 space-y-2">
+          <li>Role-based access (Agent, TL, Manager, Finance, Marketing)</li>
+          <li>Least‑privilege defaults; approval for exports</li>
+          <li>Private pipelines for high‑value deals</li>
+        </ul>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Change Management</h3>
+        <ul class="mt-2 space-y-2">
+          <li>DEV → UAT → PROD promotion</li>
+          <li>Versioned automations; rollback plan</li>
+          <li>Monthly backlog grooming with stakeholders</li>
+        </ul>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Optimization</h3>
+        <ul class="mt-2 space-y-2">
+          <li>Pipeline audits (stale stage %, velocity)</li>
+          <li>Attribution tuning & UTM hygiene</li>
+          <li>New modules/integrations evaluation</li>
+        </ul>
       </div>
     </div>
   </section>
+
+  <!-- Training -->
+
 
   <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
     <p>© <span id="year"></span> Hazem Sabu — CRM Manager (Real Estate)</p>

--- a/analytics.html
+++ b/analytics.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hazem Sabu — CRM Manager · Real Estate</title>
+  <title>Hazem Sabu — Dashboards & Insights</title>
   <meta name="description" content="Commercial & Residential CRM: pipelines, automations, data, reporting, and adoption." />
   <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23000000'/><text x='50' y='58' font-size='54' text-anchor='middle' fill='white' font-family='Arial'>CRM</text></svg>">
@@ -48,40 +48,34 @@
     </div>
   </header>
 
-  <!-- Overview / Hero -->
-  <section id="overview" class="relative overflow-hidden">
-    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
-      <div class="absolute -top-40 -left-40 w-96 h-96 rounded-full blur-3xl opacity-20 bg-indigo-400"></div>
-      <div class="absolute -bottom-48 -right-40 w-[34rem] h-[34rem] rounded-full blur-3xl opacity-20 bg-fuchsia-500"></div>
-    </div>
+    <!-- Analytics -->
+  <section id="analytics" class="container-narrow px-4 py-14">
+    <h2 class="text-2xl md:text-3xl font-bold">Dashboards & Insights</h2>
+    <p class="mt-3 text-zinc-600 dark:text-zinc-300">Demo charts below use sample data.</p>
 
-    <div class="container-narrow px-4 py-16">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
-        <div>
-          <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">Real Estate CRM Portfolio</h1>
-          <p class="mt-4 text-zinc-600 dark:text-zinc-300 text-lg">Commercial & Residential pipelines, lead scoring, automations, reporting, and governance—designed to cut response time, improve conversion, and keep data clean.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <a href="pipelines.html" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">View Work</a>
-            <a href="contact.html" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Get in touch</a>
-          </div>
-          <div class="mt-6 text-xs text-zinc-500 dark:text-zinc-400">Bitrix24 • HubSpot • Salesforce • Make/Zapier • Telephony • Property portals</div>
-        </div>
-        <div class="bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
-          <h3 class="font-semibold">What I cover</h3>
-          <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-            <li class="flex items-start gap-2"><span>✅</span>Lead capture & routing</li>
-            <li class="flex items-start gap-2"><span>✅</span>Lead scoring & qualification</li>
-            <li class="flex items-start gap-2"><span>✅</span>Sales funnels by lead type</li>
-            <li class="flex items-start gap-2"><span>✅</span>Automations & SLAs</li>
-            <li class="flex items-start gap-2"><span>✅</span>Dashboards & insights</li>
-            <li class="flex items-start gap-2"><span>✅</span>Data integrity & governance</li>
-            <li class="flex items-start gap-2"><span>✅</span>Training & enablement</li>
-            <li class="flex items-start gap-2"><span>✅</span>System administration</li>
-          </ul>
-        </div>
+    <div class="mt-8 grid lg:grid-cols-3 gap-6">
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Lead Source Performance</h3>
+        <canvas id="chartSources" height="200"></canvas>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Funnel Conversion (Residential)</h3>
+        <canvas id="chartFunnelRes" height="200"></canvas>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">SLA Compliance</h3>
+        <canvas id="chartSLA" height="200"></canvas>
       </div>
     </div>
+
+    <div class="mt-6 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+      <h3 class="font-semibold">Cycle Time by Stage (Commercial Leasing)</h3>
+      <canvas id="chartCycle" height="120"></canvas>
+    </div>
   </section>
+
+  <!-- Data Model -->
+
 
   <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
     <p>© <span id="year"></span> Hazem Sabu — CRM Manager (Real Estate)</p>

--- a/automations.html
+++ b/automations.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hazem Sabu — CRM Manager · Real Estate</title>
+  <title>Hazem Sabu — Automation & SLA Design</title>
   <meta name="description" content="Commercial & Residential CRM: pipelines, automations, data, reporting, and adoption." />
   <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23000000'/><text x='50' y='58' font-size='54' text-anchor='middle' fill='white' font-family='Arial'>CRM</text></svg>">
@@ -48,40 +48,81 @@
     </div>
   </header>
 
-  <!-- Overview / Hero -->
-  <section id="overview" class="relative overflow-hidden">
-    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
-      <div class="absolute -top-40 -left-40 w-96 h-96 rounded-full blur-3xl opacity-20 bg-indigo-400"></div>
-      <div class="absolute -bottom-48 -right-40 w-[34rem] h-[34rem] rounded-full blur-3xl opacity-20 bg-fuchsia-500"></div>
+    <!-- Automations -->
+  <section id="automations" class="container-narrow px-4 py-14">
+    <h2 class="text-2xl md:text-3xl font-bold">Automation & SLA Design</h2>
+    <p class="mt-3 text-zinc-600 dark:text-zinc-300">Robots, triggers, and queues that reduce latency and enforce quality—Bitrix24‑ready patterns.</p>
+
+    <div class="mt-8 grid lg:grid-cols-3 gap-6">
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Lead Capture & Routing</h3>
+        <ul class="mt-2 text-sm space-y-2">
+          <li>Form/portal/webhook → <strong>Validate</strong> → <strong>Enrich</strong> (email/phone check)</li>
+          <li><strong>Dedupe</strong> against Contacts/Leads (fuzzy phone/email)</li>
+          <li>Auto <strong>assign</strong> by team, source, geo, property class</li>
+          <li>Start <strong>SLA timer</strong>: 30m (residential) / 1h (commercial)</li>
+        </ul>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Nurture & Follow‑up</h3>
+        <ul class="mt-2 text-sm space-y-2">
+          <li>No contact in 24h → create task + notify team lead</li>
+          <li>Viewing scheduled → SMS/iCal reminders</li>
+          <li>Offer created → auto‑generate quote doc & checklist</li>
+          <li>Idle 7 days → escalate and recycle to nurture</li>
+        </ul>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Post‑Close & Handoff</h3>
+        <ul class="mt-2 text-sm space-y-2">
+          <li>On Won → tasks for compliance & payout</li>
+          <li>Closed Lost → capture reason & trigger remarketing</li>
+          <li>Lease expiry reminders at T‑90/T‑60/T‑30</li>
+          <li>CSAT pulse 3 days after move‑in</li>
+        </ul>
+      </div>
     </div>
 
-    <div class="container-narrow px-4 py-16">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
-        <div>
-          <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">Real Estate CRM Portfolio</h1>
-          <p class="mt-4 text-zinc-600 dark:text-zinc-300 text-lg">Commercial & Residential pipelines, lead scoring, automations, reporting, and governance—designed to cut response time, improve conversion, and keep data clean.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <a href="pipelines.html" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">View Work</a>
-            <a href="contact.html" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Get in touch</a>
-          </div>
-          <div class="mt-6 text-xs text-zinc-500 dark:text-zinc-400">Bitrix24 • HubSpot • Salesforce • Make/Zapier • Telephony • Property portals</div>
+    <div class="mt-8 grid md:grid-cols-2 gap-6">
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Automated Lead Scoring (example)</h3>
+        <p class="text-sm text-zinc-600 dark:text-zinc-400">Weights per pipeline; thresholds drive prioritization & routes.</p>
+        <div class="mt-3 text-sm bg-zinc-50 dark:bg-zinc-800 rounded-xl p-4 overflow-auto">
+<pre><code id="scoreJson">{
+  "fit": {
+    "budget_to_ask_ratio": {"weight": 30, "breakpoints": [[0.7, 0], [0.9, 10], [1.1, 20], [1.3, 30]]},
+    "property_match_score": {"weight": 20},
+    "timeline_days": {"weight": 10, "breakpoints": [[90, 0], [60, 5], [30, 10], [14, 15]]}
+  },
+  "engagement": {
+    "reply": {"weight": 15},
+    "opens": {"weight": 5},
+    "site_views": {"weight": 5}
+  },
+  "source": {
+    "priority": {"weight": 15, "map": {"referral": 15, "website": 10, "portal": 5, "list": -5}}
+  },
+  "thresholds": {"A": 70, "B": 50, "C": 30}
+}</code></pre>
+          <button onclick="downloadScore()" class="mt-3 text-xs px-3 py-2 rounded-lg border border-zinc-300 dark:border-zinc-700">Download JSON</button>
         </div>
-        <div class="bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
-          <h3 class="font-semibold">What I cover</h3>
-          <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-            <li class="flex items-start gap-2"><span>✅</span>Lead capture & routing</li>
-            <li class="flex items-start gap-2"><span>✅</span>Lead scoring & qualification</li>
-            <li class="flex items-start gap-2"><span>✅</span>Sales funnels by lead type</li>
-            <li class="flex items-start gap-2"><span>✅</span>Automations & SLAs</li>
-            <li class="flex items-start gap-2"><span>✅</span>Dashboards & insights</li>
-            <li class="flex items-start gap-2"><span>✅</span>Data integrity & governance</li>
-            <li class="flex items-start gap-2"><span>✅</span>Training & enablement</li>
-            <li class="flex items-start gap-2"><span>✅</span>System administration</li>
-          </ul>
-        </div>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Example Bitrix24 Robots & Triggers</h3>
+        <ul class="mt-2 text-sm space-y-2">
+          <li><strong>Trigger:</strong> Incoming call/email → move to <em>Qualification</em></li>
+          <li><strong>Robot @ New:</strong> Assign by queue; set SLA; send intro message</li>
+          <li><strong>Robot @ Viewing:</strong> Reminder tasks; calendar invites</li>
+          <li><strong>Robot @ Offer:</strong> Create quote; notify manager for approval</li>
+          <li><strong>Robot @ Idle:</strong> If no activity 3 days → escalate to team lead</li>
+          <li><strong>Robot @ Won:</strong> Create payout approval + finance notification</li>
+        </ul>
       </div>
     </div>
   </section>
+
+  <!-- Analytics -->
+
 
   <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
     <p>© <span id="year"></span> Hazem Sabu — CRM Manager (Real Estate)</p>

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hazem Sabu — CRM Manager · Real Estate</title>
+  <title>Hazem Sabu — Contact</title>
   <meta name="description" content="Commercial & Residential CRM: pipelines, automations, data, reporting, and adoption." />
   <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23000000'/><text x='50' y='58' font-size='54' text-anchor='middle' fill='white' font-family='Arial'>CRM</text></svg>">
@@ -48,40 +48,41 @@
     </div>
   </header>
 
-  <!-- Overview / Hero -->
-  <section id="overview" class="relative overflow-hidden">
-    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
-      <div class="absolute -top-40 -left-40 w-96 h-96 rounded-full blur-3xl opacity-20 bg-indigo-400"></div>
-      <div class="absolute -bottom-48 -right-40 w-[34rem] h-[34rem] rounded-full blur-3xl opacity-20 bg-fuchsia-500"></div>
-    </div>
-
-    <div class="container-narrow px-4 py-16">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
+    <!-- Contact -->
+  <section id="contact" class="container-narrow px-4 py-16">
+    <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-6 bg-gradient-to-br from-white to-zinc-50 dark:from-zinc-900 dark:to-zinc-900/40">
+      <div class="grid md:grid-cols-2 gap-8 items-center">
         <div>
-          <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">Real Estate CRM Portfolio</h1>
-          <p class="mt-4 text-zinc-600 dark:text-zinc-300 text-lg">Commercial & Residential pipelines, lead scoring, automations, reporting, and governance—designed to cut response time, improve conversion, and keep data clean.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <a href="pipelines.html" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">View Work</a>
-            <a href="contact.html" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Get in touch</a>
+          <h2 class="text-2xl md:text-3xl font-bold">Let’s talk</h2>
+          <p class="mt-3 text-zinc-600 dark:text-zinc-300">Open to discussing your current stack, pain points, and a 90‑day plan to lift conversion and speed.</p>
+          <div class="mt-5 text-sm space-y-1">
+            <p><strong>Email:</strong> <a class="underline" href="mailto:hazemsabu20@gmail.com">hazemsabu20@gmail.com</a></p>
+            <p><strong>Phone:</strong> <a class="underline" href="tel:+971585560929">+971585560929</a></p>
+            <p><strong>LinkedIn:</strong> <a class="underline" href="https://linkedin.com/in/hazem-sabu">linkedin.com/in/hazem-sabu</a></p>
+            <p><strong>Location:</strong> Dubai · Open to hybrid/remote</p>
           </div>
-          <div class="mt-6 text-xs text-zinc-500 dark:text-zinc-400">Bitrix24 • HubSpot • Salesforce • Make/Zapier • Telephony • Property portals</div>
         </div>
-        <div class="bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
-          <h3 class="font-semibold">What I cover</h3>
-          <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-            <li class="flex items-start gap-2"><span>✅</span>Lead capture & routing</li>
-            <li class="flex items-start gap-2"><span>✅</span>Lead scoring & qualification</li>
-            <li class="flex items-start gap-2"><span>✅</span>Sales funnels by lead type</li>
-            <li class="flex items-start gap-2"><span>✅</span>Automations & SLAs</li>
-            <li class="flex items-start gap-2"><span>✅</span>Dashboards & insights</li>
-            <li class="flex items-start gap-2"><span>✅</span>Data integrity & governance</li>
-            <li class="flex items-start gap-2"><span>✅</span>Training & enablement</li>
-            <li class="flex items-start gap-2"><span>✅</span>System administration</li>
+        <div class="bg-white/70 dark:bg-zinc-900/70 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5">
+          <h3 class="font-semibold">Role Match Checklist</h3>
+          <ul class="mt-2 text-sm space-y-2">
+            <li>☑ Lead management & funnel optimization</li>
+            <li>☑ Workflow design & automations</li>
+            <li>☑ Data integrity & reporting</li>
+            <li>☑ Marketing & sales alignment</li>
+            <li>☑ Administration & optimization</li>
+            <li>☑ Team training & enablement</li>
           </ul>
+          <div class="mt-4 flex gap-3">
+            <a href="#overview" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">Back to top</a>
+            <a href="https://hsk98.github.io/Bitrix-demo" target="_blank" rel="noopener noreferrer" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Bitrix Demo ↗</a>
+          </div>
         </div>
       </div>
     </div>
   </section>
+
+  <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
+
 
   <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
     <p>© <span id="year"></span> Hazem Sabu — CRM Manager (Real Estate)</p>

--- a/data-model.html
+++ b/data-model.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hazem Sabu — CRM Manager · Real Estate</title>
+  <title>Hazem Sabu — Data Model</title>
   <meta name="description" content="Commercial & Residential CRM: pipelines, automations, data, reporting, and adoption." />
   <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23000000'/><text x='50' y='58' font-size='54' text-anchor='middle' fill='white' font-family='Arial'>CRM</text></svg>">
@@ -48,40 +48,53 @@
     </div>
   </header>
 
-  <!-- Overview / Hero -->
-  <section id="overview" class="relative overflow-hidden">
-    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
-      <div class="absolute -top-40 -left-40 w-96 h-96 rounded-full blur-3xl opacity-20 bg-indigo-400"></div>
-      <div class="absolute -bottom-48 -right-40 w-[34rem] h-[34rem] rounded-full blur-3xl opacity-20 bg-fuchsia-500"></div>
+    <!-- Data Model -->
+  <section id="data-model" class="container-narrow px-4 py-14">
+    <h2 class="text-2xl md:text-3xl font-bold">Data Model & Entities</h2>
+    <p class="mt-3 text-zinc-600 dark:text-zinc-300">Simple, extensible structure for clean reporting and automation.</p>
+
+    <div class="mt-6 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900 overflow-auto">
+<div class="mermaid" aria-label="CRM data model diagram">
+flowchart LR
+  A[Lead] -- qualifies --> B(Deal)
+  A -- converts to --> C(Contact)
+  C -- belongs to --> D(Company)
+  B -- relates --> E[Property]
+  E -- groups --> F(Listing)
+  B -- has --> G[Viewing]
+  B -- has --> H[Offer]
+  B -- logs --> I[Activity]
+  I -- performed by --> J[Agent]
+  J -- part of --> K[Team]
+  B -- payout --> L[Commission]
+</div>
     </div>
 
-    <div class="container-narrow px-4 py-16">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
-        <div>
-          <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">Real Estate CRM Portfolio</h1>
-          <p class="mt-4 text-zinc-600 dark:text-zinc-300 text-lg">Commercial & Residential pipelines, lead scoring, automations, reporting, and governance—designed to cut response time, improve conversion, and keep data clean.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <a href="pipelines.html" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">View Work</a>
-            <a href="contact.html" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Get in touch</a>
-          </div>
-          <div class="mt-6 text-xs text-zinc-500 dark:text-zinc-400">Bitrix24 • HubSpot • Salesforce • Make/Zapier • Telephony • Property portals</div>
-        </div>
-        <div class="bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
-          <h3 class="font-semibold">What I cover</h3>
-          <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-            <li class="flex items-start gap-2"><span>✅</span>Lead capture & routing</li>
-            <li class="flex items-start gap-2"><span>✅</span>Lead scoring & qualification</li>
-            <li class="flex items-start gap-2"><span>✅</span>Sales funnels by lead type</li>
-            <li class="flex items-start gap-2"><span>✅</span>Automations & SLAs</li>
-            <li class="flex items-start gap-2"><span>✅</span>Dashboards & insights</li>
-            <li class="flex items-start gap-2"><span>✅</span>Data integrity & governance</li>
-            <li class="flex items-start gap-2"><span>✅</span>Training & enablement</li>
-            <li class="flex items-start gap-2"><span>✅</span>System administration</li>
-          </ul>
-        </div>
+    <div class="mt-6 grid md:grid-cols-2 gap-6 text-sm">
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Segmentation & Tagging</h3>
+        <ul class="mt-2 space-y-2">
+          <li>Lead Type: Buyer, Seller, Tenant, Landlord, Investor</li>
+          <li>Property Class: Apartment, Villa/Townhouse, Office, Retail, Industrial, Land</li>
+          <li>Geo: Neighborhood / Community</li>
+          <li>Budget Brackets & Bedrooms/Sqft</li>
+          <li>Source & Campaign UTM</li>
+        </ul>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Dedupe & Data Quality</h3>
+        <ul class="mt-2 space-y-2">
+          <li>Unique keys: phone E.164, email (lowercased)</li>
+          <li>Fuzzy match window (phone edit distance ≤1)</li>
+          <li>Stage-required fields & validation rules</li>
+          <li>Monthly audits, field health dashboard</li>
+        </ul>
       </div>
     </div>
   </section>
+
+  <!-- Governance -->
+
 
   <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
     <p>© <span id="year"></span> Hazem Sabu — CRM Manager (Real Estate)</p>

--- a/pipelines.html
+++ b/pipelines.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hazem Sabu — CRM Manager · Real Estate</title>
+  <title>Hazem Sabu — Pipelines & Sales Funnels</title>
   <meta name="description" content="Commercial & Residential CRM: pipelines, automations, data, reporting, and adoption." />
   <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23000000'/><text x='50' y='58' font-size='54' text-anchor='middle' fill='white' font-family='Arial'>CRM</text></svg>">
@@ -48,40 +48,110 @@
     </div>
   </header>
 
-  <!-- Overview / Hero -->
-  <section id="overview" class="relative overflow-hidden">
-    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
-      <div class="absolute -top-40 -left-40 w-96 h-96 rounded-full blur-3xl opacity-20 bg-indigo-400"></div>
-      <div class="absolute -bottom-48 -right-40 w-[34rem] h-[34rem] rounded-full blur-3xl opacity-20 bg-fuchsia-500"></div>
+    <!-- Pipelines -->
+  <section id="pipelines" class="container-narrow px-4 py-14">
+    <div class="flex items-center justify-between">
+      <h2 class="text-2xl md:text-3xl font-bold">Pipelines & Sales Funnels</h2>
+      <div class="text-sm text-zinc-500 dark:text-zinc-400">Residential · Commercial · Leasing</div>
+    </div>
+    <p class="mt-3 text-zinc-600 dark:text-zinc-300">Stage-specific required fields keep data consistent and reporting clean.</p>
+
+    <div class="mt-8 grid md:grid-cols-2 gap-6">
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold text-lg">Residential Sales</h3>
+        <ol class="mt-3 text-sm list-decimal list-inside space-y-1">
+          <li>New Lead → <span class="text-zinc-500">auto-assign + SLA 30m</span></li>
+          <li>Qualification → <span class="text-zinc-500">budget, location, beds, timeline</span></li>
+          <li>Property Match → <span class="text-zinc-500">send curated shortlist</span></li>
+          <li>Viewing Scheduled</li>
+          <li>Offer & Negotiation</li>
+          <li>Agreement/Contract</li>
+          <li>Won / Lost (reason required)</li>
+        </ol>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold text-lg">Residential Leasing</h3>
+        <ol class="mt-3 text-sm list-decimal list-inside space-y-1">
+          <li>New Inquiry</li>
+          <li>Qualification & Docs</li>
+          <li>Viewing</li>
+          <li>Application & Screening</li>
+          <li>Offer / Reservation</li>
+          <li>Contract & Move-in</li>
+          <li>Won / Lost</li>
+        </ol>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold text-lg">Commercial Sales</h3>
+        <ol class="mt-3 text-sm list-decimal list-inside space-y-1">
+          <li>Inbound / Prospect</li>
+          <li>Qualification (use case, size, power, zoning)</li>
+          <li>Viewing / Site Visit</li>
+          <li>LOI / MOU</li>
+          <li>Legal & Approvals</li>
+          <li>Contract / Transfer</li>
+          <li>Won / Lost</li>
+        </ol>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold text-lg">Commercial Leasing</h3>
+        <ol class="mt-3 text-sm list-decimal list-inside space-y-1">
+          <li>Inbound / Outreach</li>
+          <li>Qualification (trade license, timeline, fit)</li>
+          <li>Viewing / Technical</li>
+          <li>Proposal & Negotiation</li>
+          <li>HOA / Landlord Approvals</li>
+          <li>Lease Execution</li>
+          <li>Won / Lost</li>
+        </ol>
+      </div>
     </div>
 
-    <div class="container-narrow px-4 py-16">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
-        <div>
-          <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">Real Estate CRM Portfolio</h1>
-          <p class="mt-4 text-zinc-600 dark:text-zinc-300 text-lg">Commercial & Residential pipelines, lead scoring, automations, reporting, and governance—designed to cut response time, improve conversion, and keep data clean.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <a href="pipelines.html" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">View Work</a>
-            <a href="contact.html" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Get in touch</a>
-          </div>
-          <div class="mt-6 text-xs text-zinc-500 dark:text-zinc-400">Bitrix24 • HubSpot • Salesforce • Make/Zapier • Telephony • Property portals</div>
+    <div class="mt-8 rounded-2xl border border-amber-300/40 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700 p-5">
+      <h4 class="font-semibold">Stage-Required Fields</h4>
+      <div class="mt-3 grid sm:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-medium">Qualification</p>
+          <ul class="mt-2 list-disc list-inside text-zinc-600 dark:text-zinc-300">
+            <li>Budget / Rent range</li>
+            <li>Bedrooms / Sqft / Power</li>
+            <li>Move-in timeline</li>
+            <li>Lead Type & Source</li>
+          </ul>
         </div>
-        <div class="bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
-          <h3 class="font-semibold">What I cover</h3>
-          <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-            <li class="flex items-start gap-2"><span>✅</span>Lead capture & routing</li>
-            <li class="flex items-start gap-2"><span>✅</span>Lead scoring & qualification</li>
-            <li class="flex items-start gap-2"><span>✅</span>Sales funnels by lead type</li>
-            <li class="flex items-start gap-2"><span>✅</span>Automations & SLAs</li>
-            <li class="flex items-start gap-2"><span>✅</span>Dashboards & insights</li>
-            <li class="flex items-start gap-2"><span>✅</span>Data integrity & governance</li>
-            <li class="flex items-start gap-2"><span>✅</span>Training & enablement</li>
-            <li class="flex items-start gap-2"><span>✅</span>System administration</li>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-medium">Viewing</p>
+          <ul class="mt-2 list-disc list-inside text-zinc-600 dark:text-zinc-300">
+            <li>Viewing date/time</li>
+            <li>Property ID</li>
+            <li>Agent assigned</li>
+            <li>Attendees</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-medium">Offer</p>
+          <ul class="mt-2 list-disc list-inside text-zinc-600 dark:text-zinc-300">
+            <li>Offer amount / terms</li>
+            <li>Docs received</li>
+            <li>Decision-makers</li>
+            <li>Probability %</li>
+          </ul>
+        </div>
+        <div class="p-4 rounded-xl border border-zinc-200 dark:border-zinc-800">
+          <p class="font-medium">Closed</p>
+          <ul class="mt-2 list-disc list-inside text-zinc-600 dark:text-zinc-300">
+            <li>Reason Won/Lost</li>
+            <li>Commission</li>
+            <li>Marketing source</li>
+            <li>Cycle time (auto)</li>
           </ul>
         </div>
       </div>
     </div>
   </section>
+
+  <!-- Automations -->
+
 
   <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
     <p>© <span id="year"></span> Hazem Sabu — CRM Manager (Real Estate)</p>

--- a/plan-90.html
+++ b/plan-90.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hazem Sabu — CRM Manager · Real Estate</title>
+  <title>Hazem Sabu — 90-Day Plan</title>
   <meta name="description" content="Commercial & Residential CRM: pipelines, automations, data, reporting, and adoption." />
   <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23000000'/><text x='50' y='58' font-size='54' text-anchor='middle' fill='white' font-family='Arial'>CRM</text></svg>">
@@ -48,40 +48,35 @@
     </div>
   </header>
 
-  <!-- Overview / Hero -->
-  <section id="overview" class="relative overflow-hidden">
-    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
-      <div class="absolute -top-40 -left-40 w-96 h-96 rounded-full blur-3xl opacity-20 bg-indigo-400"></div>
-      <div class="absolute -bottom-48 -right-40 w-[34rem] h-[34rem] rounded-full blur-3xl opacity-20 bg-fuchsia-500"></div>
-    </div>
-
-    <div class="container-narrow px-4 py-16">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
-        <div>
-          <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">Real Estate CRM Portfolio</h1>
-          <p class="mt-4 text-zinc-600 dark:text-zinc-300 text-lg">Commercial & Residential pipelines, lead scoring, automations, reporting, and governance—designed to cut response time, improve conversion, and keep data clean.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <a href="pipelines.html" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">View Work</a>
-            <a href="contact.html" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Get in touch</a>
-          </div>
-          <div class="mt-6 text-xs text-zinc-500 dark:text-zinc-400">Bitrix24 • HubSpot • Salesforce • Make/Zapier • Telephony • Property portals</div>
-        </div>
-        <div class="bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
-          <h3 class="font-semibold">What I cover</h3>
-          <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-            <li class="flex items-start gap-2"><span>✅</span>Lead capture & routing</li>
-            <li class="flex items-start gap-2"><span>✅</span>Lead scoring & qualification</li>
-            <li class="flex items-start gap-2"><span>✅</span>Sales funnels by lead type</li>
-            <li class="flex items-start gap-2"><span>✅</span>Automations & SLAs</li>
-            <li class="flex items-start gap-2"><span>✅</span>Dashboards & insights</li>
-            <li class="flex items-start gap-2"><span>✅</span>Data integrity & governance</li>
-            <li class="flex items-start gap-2"><span>✅</span>Training & enablement</li>
-            <li class="flex items-start gap-2"><span>✅</span>System administration</li>
-          </ul>
-        </div>
-      </div>
+    <!-- 90-Day Plan -->
+  <section id="plan-90" class="container-narrow px-4 py-14">
+    <h2 class="text-2xl md:text-3xl font-bold">90‑Day Plan (Real Estate CRM)</h2>
+    <div class="prose prose-zinc dark:prose-invert max-w-none">
+      <h3>Goal</h3>
+      <p>Lift lead response speed, pipeline conversion, and data quality while aligning marketing, sales, and operations.</p>
+      <h4>Days 0–30: Assess & Stabilize</h4>
+      <ul>
+        <li>Audit pipelines, fields, automations, and permissions; document pain points.</li>
+        <li>Define qualification checklist per pipeline; enforce stage‑required fields.</li>
+        <li>Implement lead routing & SLA timers; stand up daily SLA report.</li>
+      </ul>
+      <h4>Days 31–60: Automate & Enable</h4>
+      <ul>
+        <li>Deploy nurture sequences and idle/escalation rules.</li>
+        <li>Build dashboards: lead source, funnel, agent productivity, cycle time.</li>
+        <li>Train agents & managers; publish SOPs; create templates (emails, SMS).</li>
+      </ul>
+      <h4>Days 61–90: Optimize & Scale</h4>
+      <ul>
+        <li>Attribution hygiene; UTM standards and campaign reporting.</li>
+        <li>A/B test scoring thresholds; refine routing by performance.</li>
+        <li>Integrate portals/telephony; evaluate new modules; plan Q2 backlog.</li>
+      </ul>
     </div>
   </section>
+
+  <!-- Contact -->
+
 
   <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
     <p>© <span id="year"></span> Hazem Sabu — CRM Manager (Real Estate)</p>

--- a/training.html
+++ b/training.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hazem Sabu — CRM Manager · Real Estate</title>
+  <title>Hazem Sabu — Training</title>
   <meta name="description" content="Commercial & Residential CRM: pipelines, automations, data, reporting, and adoption." />
   <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' fill='%23000000'/><text x='50' y='58' font-size='54' text-anchor='middle' fill='white' font-family='Arial'>CRM</text></svg>">
@@ -48,40 +48,37 @@
     </div>
   </header>
 
-  <!-- Overview / Hero -->
-  <section id="overview" class="relative overflow-hidden">
-    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
-      <div class="absolute -top-40 -left-40 w-96 h-96 rounded-full blur-3xl opacity-20 bg-indigo-400"></div>
-      <div class="absolute -bottom-48 -right-40 w-[34rem] h-[34rem] rounded-full blur-3xl opacity-20 bg-fuchsia-500"></div>
-    </div>
+    <!-- Training -->
+  <section id="training" class="container-narrow px-4 py-14">
+    <h2 class="text-2xl md:text-3xl font-bold">Training, SOPs & Playbooks</h2>
+    <p class="mt-3 text-zinc-600 dark:text-zinc-300">Short, role-based materials that accelerate adoption and compliance.</p>
 
-    <div class="container-narrow px-4 py-16">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
-        <div>
-          <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">Real Estate CRM Portfolio</h1>
-          <p class="mt-4 text-zinc-600 dark:text-zinc-300 text-lg">Commercial & Residential pipelines, lead scoring, automations, reporting, and governance—designed to cut response time, improve conversion, and keep data clean.</p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <a href="pipelines.html" class="px-4 py-2 rounded-xl bg-zinc-900 text-white dark:bg-white dark:text-zinc-900">View Work</a>
-            <a href="contact.html" class="px-4 py-2 rounded-xl border border-zinc-300 dark:border-zinc-700">Get in touch</a>
-          </div>
-          <div class="mt-6 text-xs text-zinc-500 dark:text-zinc-400">Bitrix24 • HubSpot • Salesforce • Make/Zapier • Telephony • Property portals</div>
-        </div>
-        <div class="bg-white/70 dark:bg-zinc-900/60 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
-          <h3 class="font-semibold">What I cover</h3>
-          <ul class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-            <li class="flex items-start gap-2"><span>✅</span>Lead capture & routing</li>
-            <li class="flex items-start gap-2"><span>✅</span>Lead scoring & qualification</li>
-            <li class="flex items-start gap-2"><span>✅</span>Sales funnels by lead type</li>
-            <li class="flex items-start gap-2"><span>✅</span>Automations & SLAs</li>
-            <li class="flex items-start gap-2"><span>✅</span>Dashboards & insights</li>
-            <li class="flex items-start gap-2"><span>✅</span>Data integrity & governance</li>
-            <li class="flex items-start gap-2"><span>✅</span>Training & enablement</li>
-            <li class="flex items-start gap-2"><span>✅</span>System administration</li>
-          </ul>
-        </div>
+    <div class="mt-6 grid md:grid-cols-2 gap-6 text-sm">
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Agent Onboarding (sample syllabus)</h3>
+        <ol class="mt-2 list-decimal list-inside space-y-1">
+          <li>CRM basics & mobile app</li>
+          <li>Working Kanban & next actions</li>
+          <li>Logging calls/emails; using templates</li>
+          <li>Viewing scheduling & client comms</li>
+          <li>Offer process & approvals</li>
+          <li>Post‑close tasks & CSAT</li>
+        </ol>
+      </div>
+      <div class="rounded-2xl border border-zinc-200 dark:border-zinc-800 p-5 bg-white dark:bg-zinc-900">
+        <h3 class="font-semibold">Manager Toolkit</h3>
+        <ul class="mt-2 space-y-2">
+          <li>Daily SLA report & stale deals</li>
+          <li>Weekly pipeline review agenda</li>
+          <li>Monthly attribution & CPL vs CVR</li>
+          <li>Quarterly automation audit</li>
+        </ul>
       </div>
     </div>
   </section>
+
+  <!-- 90-Day Plan -->
+
 
   <footer class="py-10 text-center text-xs text-zinc-500 dark:text-zinc-400">
     <p>© <span id="year"></span> Hazem Sabu — CRM Manager (Real Estate)</p>


### PR DESCRIPTION
## Summary
- Convert single-page portfolio into multi-page layout with separate pages for Pipelines, Automations, Analytics, Data Model, Admin, Training, 90-Day Plan, and Contact.
- Update navigation across all pages to link to the new standalone sections and keep overview landing page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898656df32c8325a72ace75abfd3c58